### PR TITLE
Release Frigate 0.18.0 stable for Hailo-10H

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 TZ=Europe/Stockholm
 
 # Base images / upstream refs
-FRIGATE_IMAGE=ghcr.io/blakeblackshear/frigate:0.18.0-rc1-standard-arm64
+FRIGATE_IMAGE=ghcr.io/blakeblackshear/frigate:0.18.0-standard-arm64
 VLM_REPO=https://github.com/mikehailodev/hailo-vlm-addon.git
 VLM_REF=main
 HAILORT_VERSION=5.3.0
@@ -28,3 +28,6 @@ VLM_PORT=8099
 # Frigate runtime
 FRIGATE_SHM_SIZE=256mb
 FRIGATE_CAMERA_RTSP_URL='rtsp://<url-encoded-user>:<url-encoded-password>@<camera-ip>:554/<stream>'
+
+# Optional: OpenRouter-backed Frigate GenAI. Keep the real key in .env only.
+FRIGATE_OPENROUTER_API_KEY=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026-09-13
+
+- Updated Frigate Hailo-10H build defaults to the stable `0.18.0-standard-arm64` release, keeping HailoRT 5.3.0.
+- Updated upgrade documentation and Docker Hub release references to `0.18.0` and `latest` for `msorenss79/hailo-frigate-h10`.
+- Corrected the image source label to this repository and added the `0.18.0` version label.
+
+## 2026-09-07
+
+- Updated Frigate Hailo-10H build defaults and upgrade documentation to `0.18.0-rc2-standard-arm64`.
+- Prepared the Docker Hub release tag `0.18.0-rc2` and `latest` for `msorenss79/hailo-frigate-h10`.
+
 ## 2026-09-05
 
 - Updated Frigate Hailo-10H build defaults and upgrade documentation to `0.18.0-rc1-standard-arm64`.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo is a standalone Docker Compose scaffold for running these workloads on a Raspberry Pi 5 with a Hailo-10H AI accelerator:
 
-- Frigate 0.18.0-rc1 with separate `hailo8l` and `hailo10h` detector plugins.
+- Frigate 0.18.0 stable with separate `hailo8l` and `hailo10h` detector plugins.
 - Hailo VLM Chat as a separate web/API service.
 - MQTT integration back to Home Assistant running on another machine.
 
@@ -32,21 +32,25 @@ The image now exposes both `hailo8l` and `hailo10h` detector types. Use `hailo10
 
 This scaffold has been built and smoke-tested on a Raspberry Pi 5 running Debian/Raspberry Pi OS Trixie with HailoRT 5.3.0 and a Hailo-10H device exposed as `/dev/h1x-0`.
 
-Verified for RC1 in temporary containers:
+Verified for 0.18.0 in the local Frigate build:
 
-- ARM64 image builds from `ghcr.io/blakeblackshear/frigate:0.18.0-rc1-standard-arm64` and the detector patch applies successfully.
-- Frigate reports internal version `0.18.0-a745070`, matching the upstream RC1 commit.
-- Both detector plugins import successfully; the installed Python HailoRT package is `5.3.0`.
-- The example configuration passes Frigate's configuration model validation.
-- `hailortcli fw-control identify` detects HAILO10H with firmware `5.3.0`.
+- ARM64 image builds from `ghcr.io/blakeblackshear/frigate:0.18.0-standard-arm64` and reports Frigate `0.18.0-77a66e7`.
+- Both detector plugins import and register successfully.
+- The installed Python HailoRT package is `5.3.0`.
+- HailoRT CLI `5.3.0` identifies the host accelerator as `HAILO10H`, with firmware `5.3.0`.
+- The example configuration migrates to `0.18-0` and passes Frigate validation.
+- Docker Compose configuration validation passes.
+- An isolated startup test with no cameras reaches Docker `healthy` status and serves `0.18.0-77a66e7` from `/api/version`.
 
-Camera inference and simultaneous Frigate/VLM operation were not re-tested for RC1. The earlier VLM smoke test reported `hailo_available=true` and `hailo_device=true` on port `8099`.
+The VLM image is unchanged and was not rebuilt for this release.
 
-Frigate 0.18.0 is currently a release candidate. Back up `config/frigate/config.yml` and `frigate.db` before starting this image against an existing Frigate data directory so upstream config and database migrations can be rolled back if needed.
+Camera inference and simultaneous Frigate/VLM operation were not re-tested for 0.18.0. The earlier VLM smoke test reported `hailo_available=true` and `hailo_device=true` on port `8099`.
 
-## Frigate 0.18.0 RC1 Upgrade Notes
+Back up `config/frigate/config.yml` and `frigate.db` before starting this image against an existing Frigate data directory so upstream config and database migrations can be rolled back if needed.
 
-This image uses the upstream `v0.18.0-rc1` release. RC1 adds path sanitization, camera-access restrictions for review summaries, webpush endpoint validation, and password-change rate limiting. It also fixes GenAI description activation, notification state, LPR event filtering, and export/UI issues.
+## Frigate 0.18.0 Upgrade Notes
+
+This image uses the upstream stable `v0.18.0` release. For an existing local build, update `FRIGATE_IMAGE` in `.env` to `ghcr.io/blakeblackshear/frigate:0.18.0-standard-arm64` before rebuilding; `.env` overrides the Compose default.
 
 The 0.18 upgrade still includes breaking changes that may require attention after the automatic configuration migration:
 
@@ -56,7 +60,7 @@ The 0.18 upgrade still includes breaking changes that may require attention afte
 - The `genai` configuration supports multiple providers and roles.
 - `sync_recordings`, `timelapse_args`, `ui.date_format`, and `ui.time_format` have been removed.
 
-Review the upstream [Frigate 0.18.0 RC1 release notes](https://github.com/blakeblackshear/frigate/releases/tag/v0.18.0-rc1) and take a backup before upgrading a production installation.
+Review the upstream [Frigate 0.18.0 release notes](https://github.com/blakeblackshear/frigate/releases/tag/v0.18.0) and take a backup before upgrading a production installation.
 
 The VLM service still needs a real camera source and a VLM HEF model before it can do useful image-language inference.
 
@@ -65,22 +69,22 @@ The VLM service still needs a real camera source and a VLM HEF model before it c
 A prebuilt Frigate image from this repo is published on Docker Hub:
 
 - Repository: `msorenss79/hailo-frigate-h10`
-- Tags: `0.18.0-rc1`, `latest`, `0.18.0-beta3`, `0.18.0-beta2`, `0.18.0-beta1`, `0.17.2`, `local`
+- Tags: `0.18.0`, `latest`, `0.18.0-rc2`, `0.18.0-rc1`, `0.18.0-beta3`, `0.18.0-beta2`, `0.18.0-beta1`, `0.17.2`, `local`
 - Link: https://hub.docker.com/r/msorenss79/hailo-frigate-h10
 
-The `latest` tag currently points at the 0.18.0-rc1 image. Use the versioned tag if you want an explicit release-candidate pin, or `0.17.2` if you need the previous Frigate release.
+The `latest` tag points at the stable 0.18.0 image. Use the versioned tag to pin this release, or `0.17.2` if you need the previous stable Frigate release.
 
 Pull it with:
 
 ```bash
-docker pull msorenss79/hailo-frigate-h10:0.18.0-rc1
+docker pull msorenss79/hailo-frigate-h10:0.18.0
 ```
 
 If you use the published image instead of a local build, update the Frigate service image reference accordingly in your Compose file. Prefer the versioned tag so Compose does not rely on mutable `latest` cache behavior:
 
 ```yaml
 frigate:
-   image: msorenss79/hailo-frigate-h10:0.18.0-rc1
+   image: msorenss79/hailo-frigate-h10:0.18.0
    pull_policy: always
    platform: linux/arm64
 ```

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,7 +6,7 @@ services:
     build:
       context: ./services/frigate-h10
       args:
-        FRIGATE_IMAGE: ${FRIGATE_IMAGE:-ghcr.io/blakeblackshear/frigate:0.18.0-rc1-standard-arm64}
+        FRIGATE_IMAGE: ${FRIGATE_IMAGE:-ghcr.io/blakeblackshear/frigate:0.18.0-standard-arm64}
         HAILORT_VERSION: ${HAILORT_VERSION:-5.3.0}
         HAILORT_DEB: ${HAILORT_DEB:-hailort_5.3.0_arm64.deb}
         HAILORT_WHEEL: ${FRIGATE_HAILORT_WHEEL:-hailort-5.3.0-cp311-cp311-linux_aarch64.whl}
@@ -43,6 +43,7 @@ services:
     environment:
       TZ: ${TZ:-Europe/Stockholm}
       FRIGATE_CAMERA_RTSP_URL: ${FRIGATE_CAMERA_RTSP_URL:-}
+      FRIGATE_OPENROUTER_API_KEY: ${FRIGATE_OPENROUTER_API_KEY:-}
     networks:
       - edge-ai
 

--- a/config/frigate/config.yml.example
+++ b/config/frigate/config.yml.example
@@ -20,6 +20,20 @@ model:
   labelmap_path: /labelmap/coco-80.txt
   path: https://hailo-model-zoo.s3.eu-west-2.amazonaws.com/ModelZoo/Compiled/v5.3.0/hailo10h/yolov8m.hef
 
+# OpenRouter uses Frigate's OpenAI-compatible provider. This example remains
+# disabled until it is uncommented and FRIGATE_OPENROUTER_API_KEY is set.
+# genai:
+#   openrouter:
+#     provider: openai
+#     base_url: https://openrouter.ai/api/v1
+#     api_key: "{FRIGATE_OPENROUTER_API_KEY}"
+#     model: google/gemini-2.5-flash
+#     roles:
+#       - descriptions
+#       - chat
+#     runtime_options:
+#       max_tokens: 300
+
 cameras:
   camera_1:
     enabled: true
@@ -39,6 +53,13 @@ objects:
   track:
     - person
     - car
+  # Uncomment after enabling the OpenRouter provider above. Each generated
+  # description sends camera images to the selected external model.
+  # genai:
+  #   enabled: true
+  #   objects:
+  #     - person
+  #     - car
 
 record:
   enabled: true

--- a/docs/frigate.md
+++ b/docs/frigate.md
@@ -1,8 +1,8 @@
 # Frigate Hailo-10H Service
 
-The Frigate service builds from [services/frigate-h10/Dockerfile](../services/frigate-h10/Dockerfile). It starts from `ghcr.io/blakeblackshear/frigate:0.18.0-rc1-standard-arm64`, replaces the bundled HailoRT runtime with HailoRT 5.3.0, and applies [services/frigate-h10/hailo10h_patch.py](../services/frigate-h10/hailo10h_patch.py).
+The Frigate service builds from [services/frigate-h10/Dockerfile](../services/frigate-h10/Dockerfile). It starts from `ghcr.io/blakeblackshear/frigate:0.18.0-standard-arm64`, replaces the bundled HailoRT runtime with HailoRT 5.3.0, and applies [services/frigate-h10/hailo10h_patch.py](../services/frigate-h10/hailo10h_patch.py).
 
-Frigate 0.18.0 is currently a release candidate with upstream config and database migrations. Back up `config/frigate/config.yml` and `frigate.db` before starting it against existing media/config volumes.
+Frigate 0.18.0 is a stable release with upstream config and database migrations. Back up `config/frigate/config.yml` and `frigate.db` before starting it against existing media/config volumes. For existing installations, update `FRIGATE_IMAGE` in your local `.env` to `ghcr.io/blakeblackshear/frigate:0.18.0-standard-arm64` before rebuilding; `.env` overrides the Compose default.
 
 ## Detector Configuration
 
@@ -51,6 +51,10 @@ mqtt:
 ```
 
 If your broker runs as the Mosquitto add-on in Home Assistant, use the Home Assistant host IP and the MQTT credentials configured there.
+
+## OpenRouter GenAI
+
+Frigate's existing OpenAI-compatible provider can use OpenRouter without an image patch. See [docs/openrouter.md](openrouter.md) for API-key setup, model requirements, configuration, and validation.
 
 ## Ports
 

--- a/docs/openrouter.md
+++ b/docs/openrouter.md
@@ -1,0 +1,86 @@
+# OpenRouter GenAI for Frigate
+
+Frigate 0.18 can connect to OpenRouter through its existing OpenAI-compatible GenAI provider. No Frigate source patch or additional Python package is required.
+
+OpenRouter receives the images that Frigate submits for descriptions or chat. Choose a model and retention policy appropriate for the sensitivity of your camera data. OpenRouter requests may incur usage charges.
+
+## API Key
+
+Create an API key in OpenRouter and put it in the local `.env` file:
+
+```dotenv
+FRIGATE_OPENROUTER_API_KEY=<your-openrouter-api-key>
+```
+
+Do not put the real key in `compose.yaml` or `config/frigate/config.yml`. Compose forwards it to the Frigate container, and Frigate resolves the `{FRIGATE_OPENROUTER_API_KEY}` placeholder at startup.
+
+## Provider Configuration
+
+Add this top-level block to `config/frigate/config.yml`:
+
+```yaml
+genai:
+  openrouter:
+    provider: openai
+    base_url: https://openrouter.ai/api/v1
+    api_key: "{FRIGATE_OPENROUTER_API_KEY}"
+    model: google/gemini-2.5-flash
+    roles:
+      - descriptions
+      - chat
+    runtime_options:
+      max_tokens: 300
+```
+
+The model slug is an example, not a required model. Select a current OpenRouter model that supports image input. Frigate chat also needs tool calling, while review summaries may need structured output support. Verify those capabilities and pricing in the [OpenRouter model catalog](https://openrouter.ai/models).
+
+OpenRouter's attribution headers are optional. To enable them, add OpenAI client headers under the provider:
+
+```yaml
+    provider_options:
+      default_headers:
+        HTTP-Referer: https://example.com
+        X-OpenRouter-Title: Frigate
+```
+
+## Object Descriptions
+
+Enable generation only for the object types that should leave the local system:
+
+```yaml
+objects:
+  track:
+    - person
+    - car
+  genai:
+    enabled: true
+    objects:
+      - person
+      - car
+```
+
+Frigate sends a request when a matching tracked object ends. Keep this disabled initially if the camera is busy, because every generated description can create a billable request.
+
+## Validation
+
+Validate the Compose model without making an OpenRouter request:
+
+```bash
+docker compose --env-file .env -f compose.yaml config --quiet
+```
+
+After adding the provider configuration, validate it with the same Frigate image used by this repository:
+
+```bash
+docker compose --env-file .env -f compose.yaml run --rm --no-deps \
+  --entrypoint python3 frigate-h10 -m frigate --validate-config
+```
+
+Then restart Frigate and inspect its logs:
+
+```bash
+docker compose --env-file .env -f compose.yaml up -d frigate-h10
+docker compose --env-file .env -f compose.yaml logs --tail=100 frigate-h10
+```
+
+A successful config validation does not call OpenRouter. The first chat or generated description is the first end-to-end API test and may be billable.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -77,7 +77,7 @@ Frigate 0.18 removes the old `ui.date_format` and `ui.time_format` config keys. 
 
 ## Frigate Patch Fails During Build
 
-The patch has been checked against Frigate 0.18.0-rc1. If you change `FRIGATE_IMAGE` again, the target detector plugin may have changed and the patch can fail intentionally. Re-test and update [services/frigate-h10/hailo10h_patch.py](../services/frigate-h10/hailo10h_patch.py) before upgrading Frigate.
+The patch targets Frigate 0.18.0. If you change `FRIGATE_IMAGE` again, the target detector plugin may have changed and the patch can fail intentionally. Re-test and update [services/frigate-h10/hailo10h_patch.py](../services/frigate-h10/hailo10h_patch.py) before upgrading Frigate.
 
 ## VLM Build Cannot Clone Upstream
 

--- a/services/frigate-h10/Dockerfile
+++ b/services/frigate-h10/Dockerfile
@@ -1,7 +1,7 @@
 # Standalone Frigate image with Hailo-10H support.
 # Based on the community Home Assistant add-on work from:
 # https://github.com/mikehailodev/frigate-hass-addons-h10
-ARG FRIGATE_IMAGE=ghcr.io/blakeblackshear/frigate:0.18.0-rc1-standard-arm64
+ARG FRIGATE_IMAGE=ghcr.io/blakeblackshear/frigate:0.18.0-standard-arm64
 FROM ${FRIGATE_IMAGE}
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -32,5 +32,6 @@ COPY hailo10h_patch.py /tmp/hailo10h_patch.py
 RUN python3 /tmp/hailo10h_patch.py && rm /tmp/hailo10h_patch.py
 
 LABEL org.opencontainers.image.title="Standalone Frigate Hailo-10H" \
-    org.opencontainers.image.description="Frigate 0.18.0-rc1 with HailoRT 5.3.0 and Hailo-10H detector patch" \
-      org.opencontainers.image.source="https://github.com/mikehailodev/frigate-hass-addons-h10"
+    org.opencontainers.image.description="Frigate 0.18.0 with HailoRT 5.3.0 and Hailo-10H detector patch" \
+    org.opencontainers.image.version="0.18.0" \
+    org.opencontainers.image.source="https://github.com/msorenss/hailo-frigate-standalone"


### PR DESCRIPTION
Updates the Frigate ARM64 base to stable 0.18.0 while retaining HailoRT 5.3.0 and the separate hailo8l/hailo10h plugins. Updates upgrade instructions, tested-state documentation and image metadata. Includes the previously committed optional OpenRouter configuration and guide.

Validation passed on Raspberry Pi 5: ARM64 Docker build, both detector imports and registration, example configuration migration to 0.18-0, Compose validation, HailoRT CLI/device identification (HAILO10H, firmware 5.3.0), and isolated startup reaching healthy with /api/version reporting 0.18.0-77a66e7. Live-camera inference and simultaneous VLM operation were not retested.

Published Docker Hub tags: msorenss79/hailo-frigate-h10:0.18.0 and :latest. Both resolve to sha256:51584841a0972f901220fe349d89ab01584a9c3369d21ffbb34a903ff9f880f0.